### PR TITLE
No double logs

### DIFF
--- a/DebugMod.cs
+++ b/DebugMod.cs
@@ -85,7 +85,10 @@ public partial class DebugMod : BaseUnityPlugin
     {
         LoadSettings();
 
-        if (settings.LogUnityExceptions)
+        if (settings.LogUnityExceptions
+            // If there's an existing unity log source, then messages are logged already
+            // so no need to log them separately
+            && !BepInEx.Logging.Logger.Sources.Any(x => x is BepInEx.Logging.UnityLogSource))
         {
             Application.logMessageReceived += (condition, stackTrace, type) =>
             {


### PR DESCRIPTION
I believe this is actually the best way to keep "debug mod logs unity exceptions" without annoying people who have unity logs enabled in BepInEx (which is true by default for the version of BepInEx on Silksong Thunderstore)