### PR TITLE
Added a check to ensure SceneIndex is not -1 to SceneWatcher

### DIFF
--- a/SaveStates/SceneWatcher.cs
+++ b/SaveStates/SceneWatcher.cs
@@ -37,7 +37,12 @@ public static class SceneWatcher
             AddScene(USceneManager.GetSceneAt(i), LoadSceneMode.Additive, false);
         
         USceneManager.sceneLoaded += (scene, mode) => AddScene(scene, mode);
-        USceneManager.sceneUnloaded += s => scenes.RemoveAt(scenes.FindIndex(d => d.name == s.name));
+        USceneManager.sceneUnloaded += s =>
+        {
+            var index = scenes.FindIndex(d => d.name == s.name);
+            if (index == -1) return;
+            scenes.RemoveAt(index);
+        };
     }
 
     [HarmonyPatch(typeof(CustomSceneManager), nameof(CustomSceneManager.Start))]


### PR DESCRIPTION
I've been working with scenes made at runtime using `SceneManager.CreateScene(sceneName)` and noticed an exception from the SceneWatcher class in Debug Mod when unloading a scene

<img width="566" height="283" alt="image" src="https://github.com/user-attachments/assets/0edf8f0e-6ec6-4187-b826-bef87c3f38bf" />

It seems like the scene is created at runtime the scene watcher doesn't work on it, this check prevents it from throwing an error when trying to remove the scene that doesn't exist.