### PR TITLE
Fix delayed audio after loading during mist voidout

### DIFF
--- a/SaveStates/SaveState.cs
+++ b/SaveStates/SaveState.cs
@@ -325,6 +325,8 @@ public class SaveState
 
     private IEnumerator LoadImpl()
     {
+        bool interruptedTransitionZone = false;
+
         //prevents silly things from happening
         TimeScale.Frozen = true;
         Time.fixedDeltaTime = 0.02f;
@@ -380,7 +382,9 @@ public class SaveState
         {
             if (zone.respawnRoutine != null)
             {
+                interruptedTransitionZone = true;
                 zone.StopCoroutine(zone.respawnRoutine);
+                zone.respawnRoutine = null;
                 GameManager.instance.BeginSceneTransition
                 (
                     new DebugModSaveStateSceneLoadInfo
@@ -395,6 +399,7 @@ public class SaveState
                     }
                 );
                 yield return new WaitUntil(() => !GameManager.instance.isLoading);
+                FinishInterruptedAudioTransition();
             }
         }
 
@@ -555,6 +560,11 @@ public class SaveState
         HeroController.instance.gameObject.layer = (int)PhysLayers.PLAYER;
         HeroController.instance.FinishedEnteringScene();
 
+        if (interruptedTransitionZone)
+        {
+            FinishInterruptedAudioTransition();
+        }
+
         RoomSpecific.BackwardsCompat(data.saveScene, ref data.roomSpecificOptions);
 
         if (!string.IsNullOrEmpty(data.roomSpecificOptions))
@@ -593,6 +603,14 @@ public class SaveState
 
         //set timescale back
         TimeScale.Frozen = false;
+    }
+
+    private static void FinishInterruptedAudioTransition()
+    {
+        AudioManager.BlockAudioChange = false;
+        AudioManager.CustomSceneManagerReady();
+        AudioManager.CustomSceneManagerSnapshotReady();
+        AudioManager.UnpauseActorSnapshot();
     }
 
     private static void RestoreSemiPersistent<TValue, TContainer>(TContainer[] list, SceneData.PersistentItemDataCollection<TValue, TContainer> collection)


### PR DESCRIPTION
﻿## What this fixes

When you load a savestate while the mist voidout animation is happening, the load itself can succeed, but the game audio gets into a weird half-recovered state.

After that, every time you enter another room, the room starts with a few seconds of missing audio before it comes back. It is especially noticeable in mist practice because room transitions happen constantly.

## Why it happens

The mist voidout transition starts a respawn coroutine and fades some audio snapshots as part of that transition.

DebugMod already stops that coroutine so loading the savestate does not hang, but the audio side can still be left waiting for the normal transition cleanup that never really happens. The game eventually times out of that wait, which is why the audio comes back after a short delay.

## What changed

If a savestate load interrupts an active mist-style transition-zone respawn, DebugMod now also finishes the related audio transition state instead of only stopping the coroutine.

This path only runs when a `SceneTransitionZoneBase` respawn routine was actually interrupted, so regular savestate loads should behave the same as before.

## Tested

```text
dotnet build .\DebugMod.csproj -c Debug
```

Build passed with 0 warnings and 0 errors.
