### PR TITLE
Fix warnings about coroutines on inactive object on savestate load

### DIFF
--- a/SaveStates/SaveState.cs
+++ b/SaveStates/SaveState.cs
@@ -365,8 +365,8 @@ public class SaveState
         EventRegister.SendEvent("INVENTORY CANCEL");
         DialogueBox.EndConversation();
         DialogueBox.HideInstant();
-        DialogueYesNoBox.ForceClose();
-        QuestYesNoBox.ForceClose();
+        if (DialogueYesNoBox._instance.pane.isActiveAndEnabled) DialogueYesNoBox.ForceClose();
+        if (QuestYesNoBox._instance.pane.isActiveAndEnabled) QuestYesNoBox.ForceClose();
 
         // Force end cutscenes to fix audio
         foreach (CinematicPlayer cinematicPlayer in Object.FindObjectsByType<CinematicPlayer>(FindObjectsSortMode.None))


### PR DESCRIPTION
Previously every savestate load would log these warnings:
```
Coroutine couldn't be started because the the game object 'Pane' is inactive!
Coroutine couldn't be started because the the game object 'Pane' is inactive!
```