### PR TITLE
Allow modifiers for keybindings

### DIFF
--- a/Binding.cs
+++ b/Binding.cs
@@ -1,0 +1,70 @@
+using Newtonsoft.Json;
+using System;
+using UnityEngine;
+
+namespace DebugMod;
+
+[JsonConverter(typeof(BindingJsonConverter))]
+public readonly struct Binding : IEquatable<Binding>
+{
+    public KeyCode Key { get; }
+
+    public Binding(KeyCode key)
+    {
+        Key = key;
+    }
+
+    public static implicit operator Binding(KeyCode key) => new(key);
+    public static implicit operator KeyCode(Binding binding) => binding.Key;
+    
+    #region Boilerplate
+
+    public bool Equals(Binding other) => Key == other.Key;
+    public override bool Equals(object obj) => obj is Binding other && Equals(other);
+    public override int GetHashCode() => Key.GetHashCode();
+    public static bool operator ==(Binding left, Binding right) => left.Equals(right);
+    public static bool operator !=(Binding left, Binding right) => !(left == right);
+
+    public override string ToString() => Key.ToString();
+    
+    #endregion
+    
+    #region Parsing
+
+    private static Binding Parse(string value)
+    {
+        return TryParse(value, out Binding binding) ? binding : throw new ArgumentException($"Invalid binding '{value}'");
+    }
+    
+    private static bool TryParse(string value, out Binding binding)
+    {
+        if (!Enum.TryParse(value, out KeyCode keyCode))
+        {
+            binding = default;
+            return false;
+        }
+
+        binding = new Binding(keyCode);
+        return true;
+    }
+
+    private sealed class BindingJsonConverter : JsonConverter<Binding>
+    {
+        public override void WriteJson(JsonWriter writer, Binding value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+
+        public override Binding ReadJson(JsonReader reader, Type objectType, Binding existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            return reader.Value switch
+            {
+                string name => Parse(name),
+                null => default,
+                _ => throw new ArgumentException($"Invalid binding '{reader.Value}'")
+            };
+        }
+    }
+    
+    #endregion
+}

--- a/Binding.cs
+++ b/Binding.cs
@@ -54,12 +54,12 @@ public readonly struct Binding : IEquatable<Binding>
         if (string.IsNullOrEmpty(value)) return false;
 
         string[] parts = value.Split('+');
-        if (!Enum.TryParse(parts[^1], out KeyCode key)) return false;
+        if (!Enum.TryParse(parts[^1], ignoreCase: true, out KeyCode key)) return false;
 
         Modifier modifiers = Modifier.None;
         for (int i = 0; i < parts.Length - 1; i++)
         {
-            if (!Enum.TryParse(parts[i], out Modifier flag)) return false;
+            if (!Enum.TryParse(parts[i], ignoreCase: true, out Modifier flag)) return false;
             modifiers |= flag;
         }
 

--- a/Binding.cs
+++ b/Binding.cs
@@ -15,7 +15,6 @@ public readonly struct Binding : IEquatable<Binding>
     }
 
     public static implicit operator Binding(KeyCode key) => new(key);
-    public static implicit operator KeyCode(Binding binding) => binding.Key;
     
     #region Boilerplate
 
@@ -24,6 +23,8 @@ public readonly struct Binding : IEquatable<Binding>
     public override int GetHashCode() => Key.GetHashCode();
     public static bool operator ==(Binding left, Binding right) => left.Equals(right);
     public static bool operator !=(Binding left, Binding right) => !(left == right);
+
+    public bool IsDown() => Key != KeyCode.None && Input.GetKeyDown(Key);
 
     public override string ToString() => Key.ToString();
     

--- a/Binding.cs
+++ b/Binding.cs
@@ -1,3 +1,4 @@
+using BepInEx.Configuration;
 using Newtonsoft.Json;
 using System;
 using UnityEngine;
@@ -47,6 +48,16 @@ public readonly struct Binding : IEquatable<Binding>
 
         binding = new Binding(keyCode);
         return true;
+    }
+    
+    internal static void RegisterTomlConverter()
+    {
+        if (TomlTypeConverter.CanConvert(typeof(Binding))) return;
+        TomlTypeConverter.AddConverter(typeof(Binding), new TypeConverter
+        {
+            ConvertToString = (value, _) => value.ToString(),
+            ConvertToObject = (value, _) => Parse(value),
+        });
     }
 
     private sealed class BindingJsonConverter : JsonConverter<Binding>

--- a/Binding.cs
+++ b/Binding.cs
@@ -8,26 +8,36 @@ namespace DebugMod;
 [JsonConverter(typeof(BindingJsonConverter))]
 public readonly struct Binding : IEquatable<Binding>
 {
+    public Modifier Modifiers { get; }
     public KeyCode Key { get; }
 
-    public Binding(KeyCode key)
+    public Binding(Modifier modifiers, KeyCode key)
     {
+        Modifiers = modifiers;
         Key = key;
     }
+
+    public Binding(KeyCode key) : this(Modifier.None, key) {}
 
     public static implicit operator Binding(KeyCode key) => new(key);
     
     #region Boilerplate
 
-    public bool Equals(Binding other) => Key == other.Key;
+    public bool Equals(Binding other) => Modifiers == other.Modifiers && Key == other.Key;
     public override bool Equals(object obj) => obj is Binding other && Equals(other);
-    public override int GetHashCode() => Key.GetHashCode();
+    public override int GetHashCode() => HashCode.Combine(Modifiers, Key);
     public static bool operator ==(Binding left, Binding right) => left.Equals(right);
     public static bool operator !=(Binding left, Binding right) => !(left == right);
 
-    public bool IsDown() => Key != KeyCode.None && Input.GetKeyDown(Key);
+    public bool IsDown() => IsDown(ModifierExtensions.Held());
+    public bool IsDown(Modifier modifiers) => Key != KeyCode.None && Input.GetKeyDown(Key) 
+                                                                  && (modifiers & Modifiers) == Modifiers;
 
-    public override string ToString() => Key.ToString();
+    public override string ToString()
+    {
+        if (Modifiers == Modifier.None) return Key.ToString();
+        return string.Join("+", Modifiers.Active()) + "+" + Key;
+    }
     
     #endregion
     
@@ -40,13 +50,20 @@ public readonly struct Binding : IEquatable<Binding>
     
     private static bool TryParse(string value, out Binding binding)
     {
-        if (!Enum.TryParse(value, out KeyCode keyCode))
+        binding = default;
+        if (string.IsNullOrEmpty(value)) return false;
+
+        string[] parts = value.Split('+');
+        if (!Enum.TryParse(parts[^1], out KeyCode key)) return false;
+
+        Modifier modifiers = Modifier.None;
+        for (int i = 0; i < parts.Length - 1; i++)
         {
-            binding = default;
-            return false;
+            if (!Enum.TryParse(parts[i], out Modifier flag)) return false;
+            modifiers |= flag;
         }
 
-        binding = new Binding(keyCode);
+        binding = new Binding(modifiers, key);
         return true;
     }
     

--- a/DebugMod.cs
+++ b/DebugMod.cs
@@ -86,6 +86,7 @@ public partial class DebugMod : BaseUnityPlugin
 
     public void Awake()
     {
+        Binding.RegisterTomlConverter();
         settings.InitMenu(Config);
         LoadSettings();
 

--- a/DebugMod.cs
+++ b/DebugMod.cs
@@ -232,7 +232,7 @@ public partial class DebugMod : BaseUnityPlugin
             return;
         }
 
-        settings.binds = new Dictionary<string, KeyCode>(settings.binds.OrderBy(pair => pair.Key));
+        settings.binds = new Dictionary<string, Binding>(settings.binds.OrderBy(pair => pair.Key));
 
         try
         {

--- a/DebugMod.cs
+++ b/DebugMod.cs
@@ -255,6 +255,7 @@ public partial class DebugMod : BaseUnityPlugin
         else
         {
             settings.binds.Remove(name);
+            GUIController.CancelRebind(name);
         }
         SaveSettings();
         bindUpdated?.Invoke(name, binding);

--- a/DebugMod.cs
+++ b/DebugMod.cs
@@ -82,7 +82,7 @@ public partial class DebugMod : BaseUnityPlugin
     public static readonly Dictionary<string, BindAction> bindActions = new();
     internal static readonly Dictionary<MethodInfo, BindAction> bindsByMethod = new();
     public static readonly Dictionary<KeyCode, int> alphaKeyDict = new();
-    public static event Action<string, KeyCode?> bindUpdated;
+    public static event Action<string, Binding?> bindUpdated;
 
     public void Awake()
     {
@@ -245,18 +245,18 @@ public partial class DebugMod : BaseUnityPlugin
         }
     }
 
-    public static void UpdateBind(string name, KeyCode? key)
+    public static void UpdateBind(string name, Binding? binding)
     {
-        if (key.HasValue)
+        if (binding.HasValue)
         {
-            settings.binds[name] = key.Value;
+            settings.binds[name] = binding.Value;
         }
         else
         {
             settings.binds.Remove(name);
         }
         SaveSettings();
-        bindUpdated?.Invoke(name, key);
+        bindUpdated?.Invoke(name, binding);
     }
 
     private int PlayerDamaged(int damageAmount)

--- a/GUIController.cs
+++ b/GUIController.cs
@@ -53,7 +53,9 @@ public class GUIController : MonoBehaviour
 
     private readonly List<KeyCode> UnbindableKeys = new List<KeyCode>()
     {
-        KeyCode.Mouse0
+        KeyCode.Mouse0,
+        KeyCode.LeftWindows,
+        KeyCode.RightWindows,
     };
 
     private static GUIController _instance;

--- a/GUIController.cs
+++ b/GUIController.cs
@@ -24,11 +24,25 @@ public class GUIController : MonoBehaviour
     public string respawnSceneWatch;
     private static readonly HitboxViewer hitboxes = new();
     private static Binding? keyWarning;
-    internal static string RebindTarget { get; private set; }
     private static KeyCode pendingModifierKey;
     private Size resolution;
     internal LanguageCode language;
     private bool benchwarpShifted;
+    
+    internal static event Action<string> RebindTargetChanged;
+    internal static string RebindTarget
+    {
+        get;
+        private set
+        {
+            string old = field;
+            if (old == value) return;
+            field = value;
+            RebindTargetChanged?.Invoke(old);
+            RebindTargetChanged?.Invoke(value);
+        }
+    }
+
 
     private float? lastRescale;
     private const float RebuildDelay = 0.1f;

--- a/GUIController.cs
+++ b/GUIController.cs
@@ -370,6 +370,8 @@ public class GUIController : MonoBehaviour
 
     private void HandleKeybinds()
     {
+        Modifier modifiers = ModifierExtensions.Held();
+        
         for (int i = 0; i < DebugMod.settings.binds.Count; i++)
         {
             (string bindName, Binding binding) = DebugMod.settings.binds.ElementAt(i);
@@ -415,7 +417,7 @@ public class GUIController : MonoBehaviour
                         }
                     }
                 }
-                else if (binding.IsDown())
+                else if (binding.IsDown(modifiers))
                 {
                     //This makes sure atleast you can close the UI when the KeyBindLock is active.
                     //Im sure theres a better way to do this but idk. 

--- a/GUIController.cs
+++ b/GUIController.cs
@@ -10,7 +10,6 @@ using HarmonyLib;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using TeamCherry.Localization;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -24,7 +23,8 @@ public class GUIController : MonoBehaviour
     public Vector3 hazardLocation;
     public string respawnSceneWatch;
     private static readonly HitboxViewer hitboxes = new();
-    private KeyCode keyWarning;
+    private static KeyCode keyWarning;
+    internal static string RebindTarget { get; private set; }
     private Size resolution;
     internal LanguageCode language;
     private bool benchwarpShifted;
@@ -371,79 +371,94 @@ public class GUIController : MonoBehaviour
     private void HandleKeybinds()
     {
         Modifier modifiers = ModifierExtensions.Held();
-        
-        for (int i = 0; i < DebugMod.settings.binds.Count; i++)
+
+        foreach ((string bindName, Binding binding) in DebugMod.settings.binds)
         {
-            (string bindName, Binding binding) = DebugMod.settings.binds.ElementAt(i);
+            if (bindName == RebindTarget) continue;
 
-            if (DebugMod.bindActions.ContainsKey(bindName))
+            if (binding.IsDown(modifiers))
             {
-                //check for keys that are waiting to be bound
-                if (binding.Key == KeyCode.None)
+                // This makes sure atleast you can close the UI when the KeyBindLock is active.
+                // Im sure theres a better way to do this but idk. 
+                try
                 {
-                    foreach (KeyCode kc in allKeyCodes)
+                    BindAction action;
+
+                    if (DebugMod.bindActions.TryGetValue(bindName, out action))
                     {
-                        if (Input.GetKeyDown(kc) && !UnbindableKeys.Contains(kc))
+                        //run if not locked or locked but bind doesnt allow locks
+                        if (!DebugMod.KeyBindLock || DebugMod.KeyBindLock && !action.AllowLock)
                         {
-                            if (keyWarning != kc)
-                            {
-                                foreach (string method in DebugMod.bindActions.Keys)
-                                {
-                                    if (DebugMod.settings.binds.TryGetValue(method, out Binding key) && key == kc)
-                                    {
-                                        DebugMod.LogConsole($"{kc} already bound to {Localization.Get(method)}, press again to confirm");
-                                        keyWarning = kc;
-                                    }
-                                }
-
-                                if (keyWarning == kc) break;
-                            }
-
-                            keyWarning = KeyCode.None;
-
-                            //remove bind
-                            if (kc == KeyCode.Escape)
-                            {
-                                DebugMod.UpdateBind(bindName, null);
-                                i--;
-                                DebugMod.LogWarn($"The key {Enum.GetName(typeof(KeyCode), kc)} has been unbound from {bindName}");
-                            }
-                            else if (kc != KeyCode.Escape)
-                            {
-                                DebugMod.UpdateBind(bindName, kc);
-                            }
-
-                            break;
+                            action.Action.Invoke();
                         }
                     }
+
                 }
-                else if (binding.IsDown(modifiers))
+                catch (Exception e)
                 {
-                    //This makes sure atleast you can close the UI when the KeyBindLock is active.
-                    //Im sure theres a better way to do this but idk. 
-                    try
-                    {
-                        BindAction action;
-
-                        if (DebugMod.bindActions.TryGetValue(bindName, out action))
-                        {
-                            //run if not locked or locked but bind doesnt allow locks
-                            if (!DebugMod.KeyBindLock || DebugMod.KeyBindLock && !action.AllowLock)
-                            {
-                                action.Action.Invoke();
-                            }
-                        }
-
-                    }
-                    catch (Exception e)
-                    {
-                        DebugMod.LogError("Error running keybind method " + bindName + ":\n" +
-                                                   e.ToString());
-                    }
-
+                    DebugMod.LogError("Error running keybind method " + bindName + ":\n" + e);
                 }
             }
         }
+
+        if (RebindTarget != null)
+        {
+            HandleRebind(RebindTarget);
+        }
+    }
+
+    internal static void StartRebind(string bindName)
+    {
+        RebindTarget = bindName;
+        keyWarning = default;
+    }
+
+    internal static void CancelRebind(string bindName)
+    {
+        if (RebindTarget == bindName) RebindTarget = null;
+    }
+
+    private void HandleRebind(string bindName)
+    {
+        foreach (KeyCode kc in allKeyCodes)
+        {
+            if (!UnbindableKeys.Contains(kc) && Input.GetKeyDown(kc))
+            {
+                if (keyWarning != kc)
+                {
+                    foreach (string method in DebugMod.bindActions.Keys)
+                    {
+                        if (method != bindName && DebugMod.settings.binds.TryGetValue(method, out Binding key) && key == kc)
+                        {
+                            DebugMod.LogConsole($"{kc} already bound to {Localization.Get(method)}, press again to confirm");
+                            keyWarning = kc;
+                        }
+                    }
+
+                    if (keyWarning == kc) return;
+                }
+
+                keyWarning = KeyCode.None;
+
+                if (kc == KeyCode.Escape)
+                {
+                    DebugMod.LogWarn($"The binding {bindName} has been unbound.");
+                    FinishRebind(bindName, null);
+                }
+                else
+                {
+                    FinishRebind(bindName, kc);
+                }
+
+                return;
+            }
+        }
+    }
+
+    private static void FinishRebind(string bindName, Binding? binding)
+    {
+        RebindTarget = null;
+        DebugMod.UpdateBind(bindName, binding);
     }
 
     [HarmonyPatch(typeof(InputHandler), nameof(InputHandler.SetCursorVisible))]

--- a/GUIController.cs
+++ b/GUIController.cs
@@ -389,7 +389,7 @@ public class GUIController : MonoBehaviour
                             {
                                 foreach (string method in DebugMod.bindActions.Keys)
                                 {
-                                    if (DebugMod.settings.binds.TryGetValue(method, out KeyCode key) && key == kc)
+                                    if (DebugMod.settings.binds.TryGetValue(method, out Binding key) && key == kc)
                                     {
                                         DebugMod.LogConsole($"{kc} already bound to {Localization.Get(method)}, press again to confirm");
                                         keyWarning = kc;

--- a/GUIController.cs
+++ b/GUIController.cs
@@ -23,8 +23,9 @@ public class GUIController : MonoBehaviour
     public Vector3 hazardLocation;
     public string respawnSceneWatch;
     private static readonly HitboxViewer hitboxes = new();
-    private static KeyCode keyWarning;
+    private static Binding? keyWarning;
     internal static string RebindTarget { get; private set; }
+    private static KeyCode pendingModifierKey;
     private Size resolution;
     internal LanguageCode language;
     private bool benchwarpShifted;
@@ -410,7 +411,8 @@ public class GUIController : MonoBehaviour
     internal static void StartRebind(string bindName)
     {
         RebindTarget = bindName;
-        keyWarning = default;
+        pendingModifierKey = KeyCode.None;
+        keyWarning = null;
     }
 
     internal static void CancelRebind(string bindName)
@@ -420,39 +422,68 @@ public class GUIController : MonoBehaviour
 
     private void HandleRebind(string bindName)
     {
+        Modifier held = ModifierExtensions.Held();
+
         foreach (KeyCode kc in allKeyCodes)
         {
-            if (!UnbindableKeys.Contains(kc) && Input.GetKeyDown(kc))
+            if (UnbindableKeys.Contains(kc) || !Input.GetKeyDown(kc)) continue;
+
+            if (ModifierExtensions.IsModifierKey(kc))
             {
-                if (keyWarning != kc)
-                {
-                    foreach (string method in DebugMod.bindActions.Keys)
-                    {
-                        if (method != bindName && DebugMod.settings.binds.TryGetValue(method, out Binding key) && key == kc)
-                        {
-                            DebugMod.LogConsole($"{kc} already bound to {Localization.Get(method)}, press again to confirm");
-                            keyWarning = kc;
-                        }
-                    }
+                pendingModifierKey = kc;
+                continue;
+            }
 
-                    if (keyWarning == kc) return;
-                }
-
-                keyWarning = KeyCode.None;
-
-                if (kc == KeyCode.Escape)
-                {
-                    DebugMod.LogWarn($"The binding {bindName} has been unbound.");
-                    FinishRebind(bindName, null);
-                }
-                else
-                {
-                    FinishRebind(bindName, kc);
-                }
-
+            if (kc == KeyCode.Escape)
+            {
+                DebugMod.LogWarn($"The binding {bindName} has been unbound.");
+                FinishRebind(bindName, null);
                 return;
             }
+
+            Binding candidate = new(held, kc);
+
+            if (ConfirmCandidate(bindName, candidate))
+            {
+                keyWarning = null;
+                FinishRebind(bindName, candidate);
+            }
+            else
+            {
+                pendingModifierKey = KeyCode.None;
+            }
+
+            return;
         }
+
+        // Modifier pressed and released on its own
+        if (pendingModifierKey != KeyCode.None && Input.GetKeyUp(pendingModifierKey))
+        {
+            Binding candidate = new Binding(pendingModifierKey);
+
+            if (ConfirmCandidate(bindName, candidate))
+            {
+                keyWarning = null;
+                FinishRebind(bindName, candidate);
+            }
+        }
+    }
+
+    private bool ConfirmCandidate(string bindName, Binding candidate)
+    {
+        if (keyWarning == candidate) return true;
+
+        foreach (string method in DebugMod.bindActions.Keys)
+        {
+            if (method != bindName && DebugMod.settings.binds.TryGetValue(method, out Binding key) && key == candidate)
+            {
+                DebugMod.LogConsole($"{candidate} already bound to {Localization.Get(method)}, press again to confirm");
+                keyWarning = candidate;
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static void FinishRebind(string bindName, Binding? binding)

--- a/GUIController.cs
+++ b/GUIController.cs
@@ -372,14 +372,12 @@ public class GUIController : MonoBehaviour
     {
         for (int i = 0; i < DebugMod.settings.binds.Count; i++)
         {
-            var bind = DebugMod.settings.binds.ElementAt(i);
-            string bindName = bind.Key;
-            KeyCode bindKeyCode = bind.Value;
+            (string bindName, Binding binding) = DebugMod.settings.binds.ElementAt(i);
 
             if (DebugMod.bindActions.ContainsKey(bindName))
             {
                 //check for keys that are waiting to be bound
-                if (bindKeyCode == KeyCode.None)
+                if (binding.Key == KeyCode.None)
                 {
                     foreach (KeyCode kc in allKeyCodes)
                     {
@@ -417,7 +415,7 @@ public class GUIController : MonoBehaviour
                         }
                     }
                 }
-                else if (Input.GetKeyDown(bindKeyCode))
+                else if (binding.IsDown())
                 {
                     //This makes sure atleast you can close the UI when the KeyBindLock is active.
                     //Im sure theres a better way to do this but idk. 

--- a/Modifier.cs
+++ b/Modifier.cs
@@ -11,6 +11,7 @@ public enum Modifier
     Control = 1 << 0,
     Shift = 1 << 1,
     Alt = 1 << 2,
+    Meta = 1 << 3,
 }
 
 internal static class ModifierExtensions
@@ -26,10 +27,12 @@ internal static class ModifierExtensions
     internal static Modifier Held() =>
         (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift) ? Modifier.Shift : 0) |
         (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl) ? Modifier.Control : 0) |
-        (Input.GetKey(KeyCode.LeftAlt) || Input.GetKey(KeyCode.RightAlt) ? Modifier.Alt : 0);
+        (Input.GetKey(KeyCode.LeftAlt) || Input.GetKey(KeyCode.RightAlt) ? Modifier.Alt : 0) |
+        (Input.GetKey(KeyCode.LeftMeta) || Input.GetKey(KeyCode.RightMeta) ? Modifier.Meta : 0);
 
     internal static bool IsModifierKey(KeyCode key) =>
         key is KeyCode.LeftControl or KeyCode.RightControl
             or KeyCode.LeftShift or KeyCode.RightShift
-            or KeyCode.LeftAlt or KeyCode.RightAlt;
+            or KeyCode.LeftAlt or KeyCode.RightAlt
+            or KeyCode.LeftMeta or KeyCode.RightMeta;
 }

--- a/Modifier.cs
+++ b/Modifier.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DebugMod;
+
+[Flags]
+public enum Modifier
+{
+    None = 0,
+    Control = 1 << 0,
+    Shift = 1 << 1,
+    Alt = 1 << 2,
+}
+
+internal static class ModifierExtensions
+{
+    internal static IEnumerable<Modifier> Active(this Modifier modifiers)
+    {
+        foreach (Modifier flag in Enum.GetValues(typeof(Modifier)))
+        {
+            if (flag != Modifier.None && modifiers.HasFlag(flag)) yield return flag;
+        }
+    }
+
+    internal static Modifier Held() =>
+        (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift) ? Modifier.Shift : 0) |
+        (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl) ? Modifier.Control : 0) |
+        (Input.GetKey(KeyCode.LeftAlt) || Input.GetKey(KeyCode.RightAlt) ? Modifier.Alt : 0);
+
+    internal static bool IsModifierKey(KeyCode key) =>
+        key is KeyCode.LeftControl or KeyCode.RightControl
+            or KeyCode.LeftShift or KeyCode.RightShift
+            or KeyCode.LeftAlt or KeyCode.RightAlt;
+}

--- a/Modifier.cs
+++ b/Modifier.cs
@@ -30,9 +30,23 @@ internal static class ModifierExtensions
         (Input.GetKey(KeyCode.LeftAlt) || Input.GetKey(KeyCode.RightAlt) ? Modifier.Alt : 0) |
         (Input.GetKey(KeyCode.LeftMeta) || Input.GetKey(KeyCode.RightMeta) ? Modifier.Meta : 0);
 
-    internal static bool IsModifierKey(KeyCode key) =>
-        key is KeyCode.LeftControl or KeyCode.RightControl
-            or KeyCode.LeftShift or KeyCode.RightShift
-            or KeyCode.LeftAlt or KeyCode.RightAlt
-            or KeyCode.LeftMeta or KeyCode.RightMeta;
+    internal static bool IsModifierKey(KeyCode key) => FromKeyCode(key) != Modifier.None;
+
+    internal static Modifier FromKeyCode(KeyCode key) => key switch
+    {
+        KeyCode.LeftControl or KeyCode.RightControl => Modifier.Control,
+        KeyCode.LeftShift or KeyCode.RightShift => Modifier.Shift,
+        KeyCode.LeftAlt or KeyCode.RightAlt => Modifier.Alt,
+        KeyCode.LeftMeta or KeyCode.RightMeta => Modifier.Meta,
+        _ => Modifier.None
+    };
+
+    internal static KeyCode ToKeyCode(this Modifier modifier) => modifier switch
+    {
+        Modifier.Control => KeyCode.LeftControl,
+        Modifier.Shift => KeyCode.LeftShift,
+        Modifier.Alt => KeyCode.LeftAlt,
+        Modifier.Meta => KeyCode.LeftMeta,
+        _ => throw new ArgumentException($"Cannot convert {modifier} to a key code", nameof(modifier))
+    };
 }

--- a/Settings.cs
+++ b/Settings.cs
@@ -215,11 +215,11 @@ public class Settings
                 DebugMod.UpdateBind(toggleAllUIName, toggleAllUI.Value);
             }
         };
-        DebugMod.bindUpdated += (name, key) =>
+        DebugMod.bindUpdated += (name, binding) =>
         {
             if (name == toggleAllUIName)
             {
-                toggleAllUI.Value = key ?? KeyCode.None;
+                toggleAllUI.Value = binding?.Key ?? KeyCode.None;
             }
         };
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -1,7 +1,5 @@
 using BepInEx.Configuration;
 using DebugMod.UI;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -9,8 +7,7 @@ namespace DebugMod;
 
 public class Settings
 {
-    [JsonProperty(ItemConverterType = typeof(StringEnumConverter))]
-    public Dictionary<string, KeyCode> binds = new();
+    public Dictionary<string, Binding> binds = new();
 
     private string lastLoadedPack = "";
     private string mainPanelCurrentTab;

--- a/Settings.cs
+++ b/Settings.cs
@@ -23,7 +23,7 @@ public class Settings
 
     private bool logUnityExceptions = true;
 
-    private static ConfigEntry<KeyCode> toggleAllUI;
+    private static ConfigEntry<Binding> toggleAllUI;
     private static ConfigEntry<float> noclipSpeedModifier;
     private static ConfigEntry<bool> altInfoPanel;
     private static ConfigEntry<bool> expandedInfoPanel;
@@ -201,7 +201,7 @@ public class Settings
         toggleAllUI = config.Bind(
             "General",
             "Toggle All UI Keybind",
-            KeyCode.F2,
+            new Binding(KeyCode.F2),
             "Press this key to toggle DebugMod's UI."
         );
         toggleAllUI.SettingChanged += (_, _) =>
@@ -219,7 +219,7 @@ public class Settings
         {
             if (name == toggleAllUIName)
             {
-                toggleAllUI.Value = binding?.Key ?? KeyCode.None;
+                toggleAllUI.Value = binding ?? default;
             }
         };
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -1,6 +1,7 @@
 using BepInEx.Configuration;
 using DebugMod.UI;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace DebugMod;
@@ -23,7 +24,6 @@ public class Settings
 
     private bool logUnityExceptions = true;
 
-    private static ConfigEntry<Binding> toggleAllUI;
     private static ConfigEntry<float> noclipSpeedModifier;
     private static ConfigEntry<bool> altInfoPanel;
     private static ConfigEntry<bool> expandedInfoPanel;
@@ -196,32 +196,8 @@ public class Settings
         // We store all the settings ourselves
         config.SaveOnConfigSet = false;
 
-        string toggleAllUIName = "MODUI_TOGGLEALLUI";
-
-        toggleAllUI = config.Bind(
-            "General",
-            "Toggle All UI Keybind",
-            new Binding(KeyCode.F2),
-            "Press this key to toggle DebugMod's UI."
-        );
-        toggleAllUI.SettingChanged += (_, _) =>
-        {
-            if (toggleAllUI.Value == KeyCode.None)
-            {
-                DebugMod.UpdateBind(toggleAllUIName, null);
-            }
-            else
-            {
-                DebugMod.UpdateBind(toggleAllUIName, toggleAllUI.Value);
-            }
-        };
-        DebugMod.bindUpdated += (name, binding) =>
-        {
-            if (name == toggleAllUIName)
-            {
-                toggleAllUI.Value = binding ?? default;
-            }
-        };
+        AddConfigEntryKeybind(config, "MODUI_TOGGLEALLUI", "Toggle All UI Keybind",
+            new Binding(KeyCode.F2), "Press this key to toggle DebugMod's UI.");
 
         noclipSpeedModifier = config.Bind(
             "General",
@@ -267,5 +243,42 @@ public class Settings
             false,
             "Fixes some obscure issues when using savestates, but makes loading take longer."
         );
+    }
+
+    private static void AddConfigEntryKeybind(ConfigFile config, string bindName, string displayName, Binding defaultBinding, string description)
+    {
+        // KeyboardShortcut instead of Binding, so that ConfigManager knows how to handle it
+        ConfigEntry<KeyboardShortcut> entry = config.Bind("General", displayName, ToShortcut(defaultBinding), description);
+        entry.SettingChanged += (_, _) =>
+        {
+            DebugMod.UpdateBind(bindName, ToBinding(entry.Value));
+        };
+        DebugMod.bindUpdated += (name, binding) =>
+        {
+            if (name == bindName && ToBinding(entry.Value) != binding)
+            {
+                entry.Value = ToShortcut(binding);
+            }
+        };
+    }
+
+    private static Binding? ToBinding(KeyboardShortcut shortcut)
+    {
+        if (shortcut.MainKey == KeyCode.None) return null;
+
+        Modifier modifiers = Modifier.None;
+        foreach (KeyCode key in shortcut.Modifiers)
+        {
+            modifiers |= ModifierExtensions.FromKeyCode(key);
+        }
+        return new Binding(modifiers, shortcut.MainKey);
+    }
+
+    private static KeyboardShortcut ToShortcut(Binding? binding)
+    {
+        if (binding is null || binding.Value.Key == KeyCode.None) return KeyboardShortcut.Empty;
+
+        KeyCode[] modifiers = [..binding.Value.Modifiers.Active().Select(modifier => modifier.ToKeyCode())];
+        return new KeyboardShortcut(binding.Value.Key, modifiers);
     }
 }

--- a/UI/Dialogs/KeybindDialog.cs
+++ b/UI/Dialogs/KeybindDialog.cs
@@ -77,7 +77,7 @@ public class KeybindDialog : CanvasDialog
 
         CanvasButton editButton = row.AppendSquare(new CanvasButton("Edit"));
         editButton.ImageOnly(UICommon.images["IconDotCircled"]);
-        editButton.OnClicked += () => DebugMod.UpdateBind(actions[index].Name, KeyCode.None);
+        editButton.OnClicked += () => GUIController.StartRebind(actions[index].Name);
 
         CanvasButton clearButton = row.AppendSquare(new CanvasButton("Clear"));
         clearButton.ImageOnly(UICommon.images["IconX"]);
@@ -89,9 +89,14 @@ public class KeybindDialog : CanvasDialog
 
     public static string GetKeycodeText(string action)
     {
+        if (GUIController.RebindTarget == action)
+        {
+            return Localization.Get("KEYBIND_REBINDPROMPT");
+        }
+
         if (DebugMod.settings.binds.TryGetValue(action, out Binding keycode))
         {
-            return keycode == KeyCode.None ? Localization.Get("KEYBIND_REBINDPROMPT") : keycode.ToString();
+            return keycode.ToString();
         }
         else
         {

--- a/UI/Dialogs/KeybindDialog.cs
+++ b/UI/Dialogs/KeybindDialog.cs
@@ -89,7 +89,7 @@ public class KeybindDialog : CanvasDialog
 
     public static string GetKeycodeText(string action)
     {
-        if (DebugMod.settings.binds.TryGetValue(action, out KeyCode keycode))
+        if (DebugMod.settings.binds.TryGetValue(action, out Binding keycode))
         {
             return keycode == KeyCode.None ? Localization.Get("KEYBIND_REBINDPROMPT") : keycode.ToString();
         }

--- a/UI/MainPanel.cs
+++ b/UI/MainPanel.cs
@@ -899,7 +899,8 @@ public class MainPanel : CanvasPanel
                 CanvasText keycode = builder.AppendFlex(new CanvasText("Keycode"));
                 keycode.Alignment = TextAnchor.MiddleLeft;
                 keycode.Text = KeybindDialog.GetKeycodeText(action.Name);
-                keycode.OnUpdate += () => keycode.Text = KeybindDialog.GetKeycodeText(action.Name);
+                DebugMod.bindUpdated += (name, _) => UpdateKeycodeText(name);
+                GUIController.RebindTargetChanged += UpdateKeycodeText;
 
                 CanvasButton edit = builder.AppendSquare(new CanvasButton("Edit"));
                 edit.ImageOnly(UICommon.images["IconDotCircled"]);
@@ -916,6 +917,15 @@ public class MainPanel : CanvasPanel
                 CanvasButton run = builder.AppendSquare(new CanvasButton("Run"));
                 run.ImageOnly(UICommon.images["IconRun"]);
                 run.OnClicked += action.Action;
+                continue;
+
+                void UpdateKeycodeText(string name)
+                {
+                    if (name == action.Name)
+                    {
+                        keycode.Text = KeybindDialog.GetKeycodeText(action.Name);
+                    }
+                }
             }
         }
     }

--- a/UI/MainPanel.cs
+++ b/UI/MainPanel.cs
@@ -899,17 +899,11 @@ public class MainPanel : CanvasPanel
                 CanvasText keycode = builder.AppendFlex(new CanvasText("Keycode"));
                 keycode.Alignment = TextAnchor.MiddleLeft;
                 keycode.Text = KeybindDialog.GetKeycodeText(action.Name);
-                DebugMod.bindUpdated += (name, _) =>
-                {
-                    if (name == action.Name)
-                    {
-                        keycode.Text = KeybindDialog.GetKeycodeText(action.Name);
-                    }
-                };
+                keycode.OnUpdate += () => keycode.Text = KeybindDialog.GetKeycodeText(action.Name);
 
                 CanvasButton edit = builder.AppendSquare(new CanvasButton("Edit"));
                 edit.ImageOnly(UICommon.images["IconDotCircled"]);
-                edit.OnClicked += () => DebugMod.UpdateBind(action.Name, KeyCode.None);
+                edit.OnClicked += () => GUIController.StartRebind(action.Name);
 
                 builder.AppendPadding(UICommon.Margin);
 

--- a/UI/UICommon.cs
+++ b/UI/UICommon.cs
@@ -102,7 +102,7 @@ public static class UICommon
         {
             foreach (BindAction action in actions)
             {
-                if (DebugMod.settings.binds.TryGetValue(action.Name, out KeyCode keyCode) && keyCode != KeyCode.None)
+                if (DebugMod.settings.binds.TryGetValue(action.Name, out Binding keyCode) && keyCode != KeyCode.None)
                 {
                     keybindButton.SetImage(UICommon.images["IconDot"]);
                     return;


### PR DESCRIPTION
Reworks the keybinding system around a `Binding` type containing modifier flags and the main binding.
Deserialization should stay backwards compatible.

I also refactored the rebinding logic in `GUIController` to not rely on the implicit `KeyCode.None` means "is currently rebinding" state, and instead store a `rebindTarget` action name for that. Let me know what you think about that, I can implement modifiers without making that change if you don't want it.

Keybindings in the settings file look like this: `Control+Shift+Alt+Meta+X`.

Modifiers don't distinguish between the left and the right variant, so `LCtrl+X` and `RCtrl+X` both perform a `Control + X` keybind. If you bind a modifier key alone it will be the specific key (as was the case previously), stored as `Binding { Modifiers = None, Key = KeyCode.LeftControl }`. 

Also I've made the enum parsing case insensitive, in case someone edits their config to e.g. `control+A` by hand.

The meta key handling has to be tested on windows and linux. On mac, pressing the left command key apparently emits both `LeftMeta` and `LeftWindows`, so I added `LeftWindows` and `RightWindows` to the ignored key list.

part of https://github.com/hk-speedrunning/Silksong.DebugMod/issues/170